### PR TITLE
Update getRpmPkgs.nim

### DIFF
--- a/src/funcs/packages/getRpmPkgs.nim
+++ b/src/funcs/packages/getRpmPkgs.nim
@@ -2,7 +2,4 @@ import
   std/[strutils, osproc]
 
 proc getRpmPkgs*(): string =
-  let
-    count = osproc.execCmdEx("rpm -qa")[0]
-
-  result = $(count.split("\n").len - 1)
+  result = osproc.execCmdEx("rpm -qa | wc --lines")[0]


### PR DESCRIPTION
Fixed packages issue for RHEL based distros

I noticed the same thing for debian distros, I don't know if it gives the same error there too.

Ps: I don't know nim language at all, I hope I didn't make mistakes