### PR TITLE
fixed nerd fonts icons

### DIFF
--- a/src/funcs/drawing.nim
+++ b/src/funcs/drawing.nim
@@ -20,13 +20,13 @@ proc drawInfo*(asciiArt: bool) =
   const  # icons before cotegores
     userIcon   = " "  # recomended: " " or "|>"
     hnameIcon  = " "  # recomended: " " or "|>"
-    distroIcon = " "  # recomended: " " or "|>"
-    kernelIcon = " "  # recomended: " " or "|>"
+    distroIcon = "󰌽 "  # recomended: "󰌽 " or "|>"
+    kernelIcon = " "  # recomended: " " or "|>"
     uptimeIcon = " "  # recomended: " " or "|>"
     shellIcon  = " "  # recomended: " " or "|>"
-    pkgsIcon   = " "  # recomended: " " or "|>"
-    ramIcon    = " "  # recomended: " " or "|>"
-    colorsIcon = " "  # recomended: " " or "->"
+    pkgsIcon   = "󰏖 "  # recomended: "󰏖 " or "|>"
+    ramIcon    = "󰍛 "  # recomended: "󰍛 " or "|>"
+    colorsIcon = " "  # recomended: " " or "->"
     # please insert any char after the icon
     # to avoid the bug with cropping the edge of the icon
 


### PR DESCRIPTION
Hi, I have fixed the nerd fonts icons as the nerd fonts got updated and the old icons aren't supported anymore. The icons are same except the distro icons, I suppose the names got changed.

Ronit Sadhukhan
ronit1996@outlook.com